### PR TITLE
Box API Rework

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,10 @@
+/**
+ * Copied from TSdx's repo: https://github.com/jaredpalmer/tsdx/blob/master/.eslintrc.js
+ */
+module.exports = {
+  extends: [
+    'react-app',
+    'prettier/@typescript-eslint',
+    'plugin:prettier/recommended',
+  ],
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "eslint.options": {
+    "configFile": ".eslintrc.js"
+  }
+}

--- a/sass/partials/_mixins.scss
+++ b/sass/partials/_mixins.scss
@@ -89,7 +89,6 @@
   .#{$selector} {
     @each $color in append($colors, 'grey') {
       @for $i from 1 through $shade-count {
-        @debug (#{$color}-#{$i});
         &-#{$color}-#{$i} {
           background-color: var(--#{$color}-#{$i});
         }

--- a/src/foundations/colors/index.ts
+++ b/src/foundations/colors/index.ts
@@ -23,6 +23,7 @@ export const SHADE = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 export type TShade = typeof SHADE[number];
 
 export const COLOR_SHADE = [
+  'transparent',
   'white',
   'black',
   'grey-1',

--- a/src/foundations/layout/box.tsx
+++ b/src/foundations/layout/box.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import classnames from 'classnames';
 import { TColorShade, COLOR_SHADE } from 'foundations/colors';
 import { getKeys } from 'utils/key-map';
+import { IDefaultProps } from 'types/default-props';
 
 export const SHIRT_SIZE = ['0', 's', 'm', 'l'];
 export type TShirtSize = typeof SHIRT_SIZE[number];
@@ -11,7 +12,7 @@ export type TShirtSize = typeof SHIRT_SIZE[number];
 export const DISPLAY = ['none', 'block', 'flex', 'grid', 'list-item'];
 export type TDisplay = typeof DISPLAY[number];
 
-export interface IBox {
+export interface IBox extends IDefaultProps {
   /**
    * Padding
    */
@@ -29,7 +30,6 @@ export interface IBox {
    */
   d?: TDisplay;
   inline?: boolean;
-  className?: string;
   column?: boolean;
   [key: string]: any;
 }

--- a/src/foundations/layout/box.tsx
+++ b/src/foundations/layout/box.tsx
@@ -2,108 +2,60 @@ import React, { FC } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classnames from 'classnames';
-import { IColorObject, TColorShade } from 'foundations/colors';
-import { getKeys, IKeyedObject } from 'utils/key-map';
+import { TColorShade, COLOR_SHADE } from 'foundations/colors';
+import { getKeys } from 'utils/key-map';
 
-//#region Padding
-export interface IPadding {
-  p0?: boolean;
-  ps?: boolean;
-  pm?: boolean;
-  pl?: boolean;
-}
-export const PADDING = ['p0', 'ps', 'pm', 'pl'];
-//#endregion Padding
-//#region Margin
-export interface IMargin {
-  m0?: boolean;
-  ms?: boolean;
-  mm?: boolean;
-  ml?: boolean;
-}
-export const MARGIN = ['m0', 'ms', 'mm', 'ml'];
-//#endregion Margin
-//#region Background Color
-export interface IBgColor {
-  bg?: TColorShade;
-}
-//#endregion
-//#region Display
-export interface IDisplay {
-  none?: boolean;
-  block?: boolean;
-  flex?: boolean;
-  grid?: boolean;
-  'list-item'?: boolean;
-}
+export const SHIRT_SIZE = ['0', 's', 'm', 'l'];
+export type TShirtSize = typeof SHIRT_SIZE[number];
+
 export const DISPLAY = ['none', 'block', 'flex', 'grid', 'list-item'];
-//#endregion Display
-//#region Inline
-export interface IInline {
-  inline?: boolean;
-}
-export const INLINE = ['inline'];
-//#endregion Inline
+export type TDisplay = typeof DISPLAY[number];
 
-export interface IBox extends IPadding, IMargin, IBgColor {
+export interface IBox {
+  /**
+   * Padding
+   */
+  p?: TShirtSize;
+  /**
+   * Margin
+   */
+  m?: TShirtSize;
+  /**
+   * Background Color
+   */
+  bg?: TColorShade;
+  /**
+   * Display
+   */
+  d?: TDisplay;
+  inline?: boolean;
   className?: string;
   column?: boolean;
-  [key: string]: string | boolean | IColorObject | React.ReactNode;
+  [key: string]: any;
 }
 
-interface IPropMap {
-  [key: string]: string[] | readonly string[];
-}
-
-const parseClassesFromProps = (props: IKeyedObject<any>, propMap: IPropMap) => {
-  const values = Object.values(propMap);
-  const projection = values.reduce((proj, value) => {
-    console.log('value: ', value);
-    const matchingKeys = getKeys(props, value);
-    console.log('matchingKeys: ', matchingKeys);
-    const keyToUse = matchingKeys[0];
-    console.log('keyToUse: ', keyToUse);
-    return {
-      ...proj,
-      [keyToUse]: props[keyToUse],
-    };
-  }, {});
-  const projectedKeys = Object.keys(projection);
-  console.log('projection: ', projection);
-  console.log('projectedKeys: ', projectedKeys);
-  if (projectedKeys.length === 0) {
-    return [];
-  }
-  return projectedKeys;
-};
-
-export const Box: FC<IBox> = props => {
-  const propMap = {
-    padding: PADDING,
-    margin: MARGIN,
-    display: DISPLAY,
-  };
-  const classes = parseClassesFromProps(props, propMap);
-  console.log('props: ', props);
-  console.log('classes: ', classes);
-  const bg = `bg-${props.bg || 'transparent'}`;
+export const Box: FC<IBox> = ({ children, ...props }) => {
+  const classNameKeys = ['p', 'm'];
+  const classNameProps = getKeys<IBox>(props, classNameKeys);
+  const classNames = Object.keys(classNameProps).map(
+    name => `${name}${props[name]}`
+  );
+  const bg = `bg-${props.bg}`;
   const column =
-    props.display === 'flex' ? (props.column && 'column') || 'row' : undefined;
+    props.d === 'flex' ? (props.column && 'column') || 'row' : undefined;
   return (
-    <div className={classnames(props.className, bg, column)}>{props.children}</div>
+    <div className={classnames(props.className, props.d, bg, column, ...classNames)}>
+      {children}
+    </div>
   );
 };
 Box.propTypes = {
-  ...DISPLAY.reduce(
-    (propTypes, prop) => ({
-      ...propTypes,
-      [prop]: PropTypes.bool,
-    }),
-    {}
-  ),
+  d: PropTypes.oneOf(DISPLAY),
+  bg: PropTypes.oneOf(COLOR_SHADE),
 };
 Box.defaultProps = {
-  flex: true,
+  d: 'flex',
+  bg: 'transparent',
 };
 
 export const Block = styled(Box)`

--- a/src/foundations/layout/story-components.tsx
+++ b/src/foundations/layout/story-components.tsx
@@ -1,28 +1,84 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Box as Bx } from 'foundations/layout';
 import { Fonts } from 'foundations/typography';
+import { SHADE, TColorShade } from 'foundations/colors';
+
+//#region Box Components
+interface ISizeTable {
+  propName: string;
+  styleName: string;
+}
+const SizeTable: FC<ISizeTable> = ({ propName, styleName }) => (
+  <Bx>
+    <Bx column p="s">
+      <Fonts.Body bold>Values</Fonts.Body>
+      <Fonts.Body>{propName}="s"</Fonts.Body>
+      <Fonts.Body>{propName}="m"</Fonts.Body>
+      <Fonts.Body>{propName}="l"</Fonts.Body>
+    </Bx>
+    <Bx column p="s">
+      <Fonts.Body bold>Effect</Fonts.Body>
+      <Fonts.Body>{styleName}: .5em</Fonts.Body>
+      <Fonts.Body>{styleName}: 1em</Fonts.Body>
+      <Fonts.Body>{styleName}: 2em</Fonts.Body>
+    </Bx>
+  </Bx>
+);
+
+interface IBgColorTable {
+  color: string;
+}
+const BgColorTable: FC<IBgColorTable> = ({ color }) => (
+  <Bx column>
+    {SHADE.map(shade => {
+      const colorShade = `${color}-${shade}`;
+      return (
+        <Bx key={colorShade}>
+          <Fonts.Body>bg="{colorShade}"</Fonts.Body>
+          <Bx m="s" bg={colorShade as TColorShade} p="m" />
+        </Bx>
+      );
+    })}
+  </Bx>
+);
+
+const DisplayTable: FC<{}> = () => (
+  <Bx>
+    <Bx column p="s">
+      <Fonts.Body bold>Values</Fonts.Body>
+      <Fonts.Body>d="none"</Fonts.Body>
+      <Fonts.Body>d="block"</Fonts.Body>
+      <Fonts.Body>d="flex"</Fonts.Body>
+      <Fonts.Body>d="grid"</Fonts.Body>
+      <Fonts.Body>d="list-item"</Fonts.Body>
+    </Bx>
+    <Bx column p="s">
+      <Fonts.Body bold>Effect</Fonts.Body>
+      <Fonts.Body>display: none</Fonts.Body>
+      <Fonts.Body>display: block</Fonts.Body>
+      <Fonts.Body>display: flex</Fonts.Body>
+      <Fonts.Body>display: grid</Fonts.Body>
+      <Fonts.Body>display: list-item</Fonts.Body>
+    </Bx>
+  </Bx>
+);
+//#endregion Box Components
 
 export const Box = () => (
   <Bx d="block">
     <Fonts.Title>Box</Fonts.Title>
     <Fonts.Subtitle>Configuration</Fonts.Subtitle>
     <Fonts.SectionTitle>Padding</Fonts.SectionTitle>
-    <Bx>
-      <Bx column p="s">
-        <Fonts.Body bold>Values</Fonts.Body>
-        <Fonts.Body>p="s"</Fonts.Body>
-        <Fonts.Body>p="m"</Fonts.Body>
-        <Fonts.Body>p="l"</Fonts.Body>
-      </Bx>
-      <Bx column p="s">
-        <Fonts.Body bold>Effect</Fonts.Body>
-        <Fonts.Body>padding: .5em</Fonts.Body>
-        <Fonts.Body>padding: 1em</Fonts.Body>
-        <Fonts.Body>padding: 2em</Fonts.Body>
-      </Bx>
-    </Bx>
+    <SizeTable propName="p" styleName="padding" />
     <Fonts.SectionTitle>Margin</Fonts.SectionTitle>
+    <SizeTable propName="s" styleName="margin" />
     <Fonts.SectionTitle>Background Color</Fonts.SectionTitle>
+    <Bx>
+      <BgColorTable color="azure" />
+      <BgColorTable color="seafoam" />
+      <BgColorTable color="red" />
+    </Bx>
     <Fonts.SectionTitle>Display</Fonts.SectionTitle>
+    <DisplayTable />
   </Bx>
 );

--- a/src/foundations/layout/story-components.tsx
+++ b/src/foundations/layout/story-components.tsx
@@ -3,18 +3,18 @@ import { Box as Bx } from 'foundations/layout';
 import { Fonts } from 'foundations/typography';
 
 export const Box = () => (
-  <Bx block>
+  <Bx d="block">
     <Fonts.Title>Box</Fonts.Title>
     <Fonts.Subtitle>Configuration</Fonts.Subtitle>
     <Fonts.SectionTitle>Padding</Fonts.SectionTitle>
     <Bx>
-      <Bx column pm block>
+      <Bx column p="s">
         <Fonts.Body bold>Values</Fonts.Body>
-        <Fonts.Body>ps</Fonts.Body>
-        <Fonts.Body>pm</Fonts.Body>
-        <Fonts.Body>pl</Fonts.Body>
+        <Fonts.Body>p="s"</Fonts.Body>
+        <Fonts.Body>p="m"</Fonts.Body>
+        <Fonts.Body>p="l"</Fonts.Body>
       </Bx>
-      <Bx column>
+      <Bx column p="s">
         <Fonts.Body bold>Effect</Fonts.Body>
         <Fonts.Body>padding: .5em</Fonts.Body>
         <Fonts.Body>padding: 1em</Fonts.Body>

--- a/src/foundations/typography/index.tsx
+++ b/src/foundations/typography/index.tsx
@@ -70,7 +70,7 @@ const Bold: FC<ChildrenAsReactNode> = props => <b {...props} />;
 const wrapChildren = (
   Em: FC<ChildrenAsReactNode>,
   B: FC<ChildrenAsReactNode>,
-  children: string
+  children: React.ReactNode
 ) => (
   <Em>
     <B>{children}</B>
@@ -97,8 +97,7 @@ export const TEXT_TRANSFORM = ['none', 'uppercase', 'lowercase', 'capitalize'];
 
 type TBaseFont = IFontTag & IFontType & IFontStyle & ITextAlign & ITextTransform;
 
-interface IBaseFont extends TBaseFont {
-  children: string;
+interface IBaseFont extends TBaseFont, ChildrenAsReactNode {
   [key: string]: any;
 }
 

--- a/src/types/default-props.ts
+++ b/src/types/default-props.ts
@@ -1,0 +1,14 @@
+export interface IDefaultProps {
+  /**
+   * All Components may be given an `id` attribute to uniquely identify them
+   * within the document.
+   */
+  id?: string;
+  /**
+   * All Components may be given a `className` attribute to apply custom styling via
+   * an externally defined `className`.  This provides support for 3rd party tools like
+   * `styled-components` & `emotion` or for the application of custom styles by users
+   * of these components
+   */
+  className?: string;
+}

--- a/src/utils/key-map.ts
+++ b/src/utils/key-map.ts
@@ -1,13 +1,13 @@
 import { isNullOrUndefined } from './type-guards';
 
 export interface IKeyedObject<T = {}> {
-  [key: string]: T | undefined;
+  [key: string]: T;
 }
 export const getKeys = <T>(
   obj: IKeyedObject<T>,
-  keys: any[] | readonly any[] = [],
+  keys: string[] = [],
   defaultValue: IKeyedObject<T> | undefined = undefined
-): T => {
+): Partial<T> => {
   if (isNullOrUndefined(obj) || keys.length === 0) {
     return {} as T;
   }


### PR DESCRIPTION
## Motivation
There are too many background colors to support a performant API leveraging booleans to configure which background color to use:

**Desired Approach (risk of bad performance at scale)**
```
<Box bg-grey10 />
```

**Traditional Approach (tried & true)**
```
<Box bg="grey-10" />
```

The **Desired Approach** is more succinct and reduces the variance in keys use to apply props to a component.  This approach scales well for other props such as the `bold` / `strong` / `emphasis` / `italics` prop combination because there are only a few possible options.  Colors consist of 9 shades of 12 colors by default and should be available for use defining the following styles (including, but not limited to):
* `background-color`
* `boder-color`
* `color`
* `box-shadow` colors

## Solution
* Traditional approach to prop naming and definition will be used to support highly configurable props such as those that are defined by colors
* Experimental API may be used for prop configurations with only a dozen possible values or less