### PR TITLE
Add base grid configurations to get things started

### DIFF
--- a/.loki/reference/chrome_laptop_Foundations_Layout_Grid.png
+++ b/.loki/reference/chrome_laptop_Foundations_Layout_Grid.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a950bc610affc752e1bfa7bcf48f3ad6c17c43760ca86ee41451ec970dc3ddb6
+size 62836

--- a/sass/foundations/layout.scss
+++ b/sass/foundations/layout.scss
@@ -14,6 +14,23 @@ $justification: flex-start, flex-end, center, stretch, space-between, space-arou
 @include mix-sizes(p, padding, $space-sizes, $bem: false);
 @include mix-sizes(m, margin, $space-sizes, $bem: false);
 
+@mixin align-self-and-items() {
+  &--as {
+    @each $align in $alignment {
+      &-#{$align} {
+        align-self: #{$align};
+      }
+    }
+  }
+  &--ai {
+    @each $align in $alignment {
+      &-#{$align} {
+        align-items: #{$align};
+      }
+    }
+  }
+}
+
 .bg--transparent {
   background-color: transparent;
 }
@@ -102,20 +119,7 @@ $justification: flex-start, flex-end, center, stretch, space-between, space-arou
   &.auto {
     flex: 1 1 auto;
   }
-  &--as {
-    @each $align in $alignment {
-      &-#{$align} {
-        align-self: #{$align};
-      }
-    }
-  }
-  &--ai {
-    @each $align in $alignment {
-      &-#{$align} {
-        align-items: #{$align};
-      }
-    }
-  }
+  @include align-self-and-items;
   &--jc {
     @each $justify in $justification {
       &-#{$justify} {
@@ -126,6 +130,31 @@ $justification: flex-start, flex-end, center, stretch, space-between, space-arou
 }
 .grid {
   display: grid;
+  $grid: &;
+  @include align-self-and-items;
+
+  &--tbt {
+    grid-template-columns: repeat(12, 1fr);
+    grid-auto-rows: minmax(1fr, 1fr);
+    gap: map-get($space-sizes, s);
+  }
+
+  &--hbf {
+    grid-template-columns: 1fr;
+    grid-template-rows:
+      minmax(min-content, 1fr) minmax(min-content, auto)
+      minmax(min-content, 1fr);
+    grid-template-areas: 'header' 'body' 'footer';
+    #{$grid}-header {
+      grid-area: header;
+    }
+    #{$grid}-body {
+      grid-area: body;
+    }
+    #{$grid}-footer {
+      grid-area: footer;
+    }
+  }
 }
 .list-item {
   display: list-item;

--- a/src/_stories/foundations/layout/layout-story-components.tsx
+++ b/src/_stories/foundations/layout/layout-story-components.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex as Fx, Fonts, Column } from 'foundations';
+import { Flex as Fx, Fonts, Column, Grid as Gd, HBFGrid } from 'foundations';
 import { IKeyedObject } from '../../../utilities';
 import {
   Story,
@@ -221,3 +221,55 @@ export const Block = () => (
   </Story>
 );
 //#endregion Block
+//#region Grid
+export const Grid = () => {
+  const tbtGrid = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+  return (
+    <Story title="Layout - Grid">
+      <Fx>
+        <Fonts.Subtitle>Description</Fonts.Subtitle>
+      </Fx>
+      <Column>
+        <Fonts.Body>
+          Grids are layouts that may be used to arrange UI elements according to a
+          grid that divides an area into rows &amp; columns. There are a variety of
+          predefined grids available in our toolkit including Twelve-by-Twelve &amp;
+          Header-Body-Footer.
+        </Fonts.Body>
+        <Fx />
+        <Fx bg="red-2" p="0">
+          <Fx p="s" bg="red-6" />
+          <Fx p="s" />
+          <Fonts.Body>
+            Notice how some grids have gutters / alleys while some do not!
+          </Fonts.Body>
+        </Fx>
+      </Column>
+      <Fx>
+        <Column>
+          <Fonts.SectionSubtitle>Twelve-By-Twelve (tbt)</Fonts.SectionSubtitle>
+          <Gd gridType="tbt">
+            {tbtGrid.map(row =>
+              tbtGrid.map(col => <Fx key={`${row}-${col}`} p="s" bg="grey-3" />)
+            )}
+          </Gd>
+        </Column>
+        <Column>
+          <Fonts.SectionSubtitle>Header-Body-Footer (hbf)</Fonts.SectionSubtitle>
+          <HBFGrid>
+            <HBFGrid.Header p="s" bg="grey-3">
+              <Fonts.SectionTitle>Header</Fonts.SectionTitle>
+            </HBFGrid.Header>
+            <HBFGrid.Body p="s" bg="grey-3">
+              <Fonts.SectionTitle>Body</Fonts.SectionTitle>
+            </HBFGrid.Body>
+            <HBFGrid.Footer p="s" bg="grey-3">
+              <Fonts.SectionTitle>Footer</Fonts.SectionTitle>
+            </HBFGrid.Footer>
+          </HBFGrid>
+        </Column>
+      </Fx>
+    </Story>
+  );
+};
+//#endregion Grid

--- a/src/_stories/foundations/layout/layout.stories.tsx
+++ b/src/_stories/foundations/layout/layout.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Flex, Block } from './layout-story-components';
+import { Box, Flex, Block, Grid } from './layout-story-components';
 
 export default {
   title: 'Foundations/Layout',
@@ -8,3 +8,4 @@ export default {
 export const box = () => <Box />;
 export const flex = () => <Flex />;
 export const block = () => <Block />;
+export const grid = () => <Grid />;

--- a/src/foundations/layout/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/src/foundations/layout/__tests__/__snapshots__/grid.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Grid Base Grid Renders default 1`] = `
+<div
+  class="grid--tbt grid p0 m0"
+>
+  grid
+</div>
+`;

--- a/src/foundations/layout/__tests__/grid.test.tsx
+++ b/src/foundations/layout/__tests__/grid.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Grid } from 'foundations';
+import { render } from '@testing-library/react';
+import { renderAndTestProps } from '../../../utilities';
+import { GRID_DISPLAY, GRID_TYPE } from '../grid';
+
+describe('Grid', () => {
+  describe('Base Grid', () => {
+    it('Renders default', () => {
+      const { getByText } = render(<Grid>grid</Grid>);
+      const grid = getByText('grid');
+      expect(grid).toMatchSnapshot();
+      expect(grid).toHaveClass('grid', 'p0', 'grid--tbt');
+    });
+    it('Handles display props', () => {
+      renderAndTestProps(Grid, GRID_DISPLAY, 'd');
+    });
+    it('Handles grid type props', () => {
+      renderAndTestProps(Grid, GRID_TYPE, 'gridType', 'grid--');
+    });
+  });
+});

--- a/src/foundations/layout/block.tsx
+++ b/src/foundations/layout/block.tsx
@@ -4,7 +4,7 @@ import { Box, IBox } from './box';
 import { createClassName } from '../../utilities';
 
 export const BLOCK_DISPLAY = ['none', 'block', 'inline-block'] as const;
-type TBlockDisplay = 'none' | 'block' | 'inline-block';
+type TBlockDisplay = typeof BLOCK_DISPLAY[number];
 
 //#region Text Overflow
 export const TEXT_OVERFLOW = ['clip', 'ellipsis'] as const;

--- a/src/foundations/layout/flex.tsx
+++ b/src/foundations/layout/flex.tsx
@@ -28,7 +28,7 @@ export type TFlex = typeof FLEX[number];
 //#endregion Flex
 
 export const FLEX_DISPLAY = ['none', 'flex', 'inline-flex'] as const;
-type TFlexDisplay = 'none' | 'flex' | 'inline-flex';
+type TFlexDisplay = typeof FLEX_DISPLAY[number];
 
 export interface IFlex extends IBox {
   /** Display */

--- a/src/foundations/layout/grid.tsx
+++ b/src/foundations/layout/grid.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react';
+import classnames from 'classnames';
+import { Box, IBox } from './box';
+import { createClassName } from '../../utilities';
+
+export const GRID_DISPLAY = ['none', 'grid', 'inline-grid'] as const;
+type TGridDisplay = typeof GRID_DISPLAY[number];
+
+//#region Grid Type
+export const GRID_TYPE = ['tbt', 'hbf'] as const;
+export type TGridType = typeof GRID_TYPE[number];
+//#endregion Grid Type
+
+export interface IGrid extends IBox {
+  /** Display */
+  d?: TGridDisplay;
+  /** Grid Type */
+  gridType?: TGridType;
+}
+
+export const Grid: FC<IGrid> = ({ className, gridType, ...props }) => {
+  const gridStyles = {
+    'grid--': gridType,
+  };
+  const blockClassNames = createClassName(gridStyles);
+  return <Box {...props} className={classnames(className, blockClassNames)} />;
+};
+Grid.defaultProps = {
+  d: 'grid',
+  gridType: 'tbt',
+  p: '0',
+};

--- a/src/foundations/layout/grids/__tests__/__snapshots__/header-body-footer.test.tsx.snap
+++ b/src/foundations/layout/grids/__tests__/__snapshots__/header-body-footer.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Grid HBF Grid Renders default 1`] = `
+<div
+  class="grid--hbf grid p0 m0"
+>
+  <div
+    class="grid-header flex pm m0"
+  >
+    Header
+  </div>
+  <div
+    class="grid-body flex pm m0"
+  >
+    Body
+  </div>
+  <div
+    class="grid-footer flex pm m0"
+  >
+    Footer
+  </div>
+</div>
+`;

--- a/src/foundations/layout/grids/__tests__/header-body-footer.test.tsx
+++ b/src/foundations/layout/grids/__tests__/header-body-footer.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { HBFGrid } from 'foundations';
+import { render } from '@testing-library/react';
+
+describe('Grid', () => {
+  describe('HBF Grid', () => {
+    it('Renders default', () => {
+      const { baseElement, getByText } = render(
+        <HBFGrid>
+          <HBFGrid.Header>Header</HBFGrid.Header>
+          <HBFGrid.Body>Body</HBFGrid.Body>
+          <HBFGrid.Footer>Footer</HBFGrid.Footer>
+        </HBFGrid>
+      );
+      const grid = baseElement.children[0].children[0];
+      const header = getByText('Header');
+      const body = getByText('Body');
+      const footer = getByText('Footer');
+      expect(grid).toMatchSnapshot();
+      expect(grid).toHaveClass('grid', 'p0', 'grid--hbf');
+      expect(header).toHaveClass('grid-header');
+      expect(body).toHaveClass('grid-body');
+      expect(footer).toHaveClass('grid-footer');
+    });
+  });
+});

--- a/src/foundations/layout/grids/header-body-footer.tsx
+++ b/src/foundations/layout/grids/header-body-footer.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+import classnames from 'classnames';
+import { IBox, Box } from '../box';
+import { Grid, IGrid } from '../grid';
+
+const HBFHeader: FC<IBox> = ({ className, ...props }) => (
+  <Box {...props} className={classnames(className, 'grid-header')} />
+);
+const HBFBody: FC<IBox> = ({ className, ...props }) => (
+  <Box {...props} className={classnames(className, 'grid-body')} />
+);
+const HBFFooter: FC<IBox> = ({ className, ...props }) => (
+  <Box {...props} className={classnames(className, 'grid-footer')} />
+);
+
+type THBFGrid = Omit<IGrid, 'gridType'>;
+
+export class HBFGrid extends React.PureComponent<THBFGrid> {
+  static Header = HBFHeader;
+  static Body = HBFBody;
+  static Footer = HBFFooter;
+
+  render() {
+    return <Grid {...this.props} gridType="hbf" />;
+  }
+}

--- a/src/foundations/layout/grids/index.tsx
+++ b/src/foundations/layout/grids/index.tsx
@@ -1,0 +1,1 @@
+export * from './header-body-footer';

--- a/src/foundations/layout/index.ts
+++ b/src/foundations/layout/index.ts
@@ -1,5 +1,7 @@
 import { Box } from './box';
 import { Block } from './block';
+import { Grid } from './grid';
+import { HBFGrid } from './grids';
 import { Flex, Row, Column } from './flex';
 
-export { Block, Box, Flex, Row, Column };
+export { Block, Box, Flex, Row, Column, Grid, HBFGrid };


### PR DESCRIPTION
## Net New
* `grid`, `grid--tbt`, & `grid--hbf` - Core grid, 12x12 grid, and Header + Body + Footer grid to create baseline grid support
* `Grid` & `HBFGrid` to reduce prop fatigue when using pre-defined Grid layouts
  * `HBFGrid` has 3 static members: `Header`, `Body`, `Footer` for better control over how items are placed into the layout

## Updates
* `align-self-and-items` mixin for recreating shared styles across `grid` & `flex`
* Remove duplicated definitions for `Block` & `Flex` `TBlockDisplay` definitions